### PR TITLE
deps: babel5 - babel6

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,12 @@
   ],
   "dependencies": {
     "autoprefixer-loader": "~2.0.0",
-    "babel-core": "~5.8.32",
-    "babel-loader": "~5.3.2",
+    "babel-core": "~6.1.21",
+    "babel-loader": "~6.2.0",
+    "babel-plugin-add-module-exports": "~0.1.1",
+    "babel-preset-es2015": "~6.1.18",
+    "babel-preset-react": "~6.1.18",
+    "babel-preset-stage-0": "~6.1.18",
     "chalk": "~1.0.0",
     "commander": "~2.8.1",
     "css-loader": "~0.21.0",
@@ -56,5 +60,17 @@
     ],
     "unmockedModulePathPatterns": [],
     "verbose": true
+  },
+  "babel": {
+    "presets": [
+      "es2015",
+      "stage-0"
+    ],
+    "only": [
+      "src/*.js"
+    ],
+    "plugins": [
+      "add-module-exports"
+    ]
   }
 }

--- a/src/getWebpackCommonConfig.js
+++ b/src/getWebpackCommonConfig.js
@@ -34,12 +34,13 @@ export default function getWebpackCommonConfig(args) {
       loaders: [
         {
           test: /\.jsx$/,
-          loaders: ['babel?stage=0'],
+          exclude: /node_modules/,
+          loaders: ['babel?presets[]=react,presets[]=es2015'],
         },
         {
           test: /\.js$/,
           exclude: /node_modules/,
-          loader: 'babel?stage=0',
+          loader: 'babel?presets[]=react,presets[]=es2015',
         },
         {
           test: /\.css$/,


### PR DESCRIPTION
Close ant-design/ant-design#457

----

感觉 babel 6 有性能问题。一个最简单的例子，webpack 的打包和 `babel-core/register` 都慢很多：

babel6

```bash
$ time atool-build --debug
Hash: 3475bf357b668726adbc
Version: webpack 1.12.6
Time: 834ms
        Asset       Size  Chunks             Chunk Names
    common.js    3.68 kB       0  [emitted]  common
     index.js  130 bytes    1, 0  [emitted]  index
common.js.map    3.71 kB       0  [emitted]  common
 index.js.map  265 bytes    1, 0  [emitted]  index
chunk    {0} common.js, common.js.map (common) 0 bytes [rendered]
chunk    {1} index.js, index.js.map (index) 17 bytes {0} [rendered]
    [0] ./index.js 17 bytes {1} [built]
atool-build --debug  6.29s user 1.07s system 79% cpu 9.251 total
```

babel5

```bash
$ time atool-build --debug
Hash: 9b844674ff0c73760b4c
Version: webpack 1.12.6
Time: 195ms
        Asset       Size  Chunks             Chunk Names
    common.js    3.68 kB       0  [emitted]  common
     index.js  144 bytes    1, 0  [emitted]  index
common.js.map    3.71 kB       0  [emitted]  common
 index.js.map  240 bytes    1, 0  [emitted]  index
chunk    {0} common.js, common.js.map (common) 0 bytes [rendered]
chunk    {1} index.js, index.js.map (index) 30 bytes {0} [rendered]
    [0] ./index.js 30 bytes {1} [built]
atool-build --debug  1.64s user 0.22s system 64% cpu 2.894 total
```
