### PR TITLE
support node builtins

### DIFF
--- a/src/__tests__/build-test.js
+++ b/src/__tests__/build-test.js
@@ -56,4 +56,7 @@ describe('lib/build', () => {
   pit('should support json', () => {
     return testBuild({}, 'build-json');
   });
+  pit('should support node builtins', () => {
+    return testBuild({}, 'build-node-builtins');
+  });
 });

--- a/src/__tests__/expect/build-node-builtins/common.js
+++ b/src/__tests__/expect/build-node-builtins/common.js
@@ -1,0 +1,94 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// install a JSONP callback for chunk loading
+/******/ 	var parentJsonpFunction = window["webpackJsonp"];
+/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules) {
+/******/ 		// add "moreModules" to the modules object,
+/******/ 		// then flag all "chunkIds" as loaded and fire callback
+/******/ 		var moduleId, chunkId, i = 0, callbacks = [];
+/******/ 		for(;i < chunkIds.length; i++) {
+/******/ 			chunkId = chunkIds[i];
+/******/ 			if(installedChunks[chunkId])
+/******/ 				callbacks.push.apply(callbacks, installedChunks[chunkId]);
+/******/ 			installedChunks[chunkId] = 0;
+/******/ 		}
+/******/ 		for(moduleId in moreModules) {
+/******/ 			modules[moduleId] = moreModules[moduleId];
+/******/ 		}
+/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules);
+/******/ 		while(callbacks.length)
+/******/ 			callbacks.shift().call(null, __webpack_require__);
+/******/ 		if(moreModules[0]) {
+/******/ 			installedModules[0] = 0;
+/******/ 			return __webpack_require__(0);
+/******/ 		}
+/******/ 	};
+
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// object to store loaded and loading chunks
+/******/ 	// "0" means "already loaded"
+/******/ 	// Array means "loading", array contains callbacks
+/******/ 	var installedChunks = {
+/******/ 		0:0
+/******/ 	};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+/******/ 	// This file contains only the entry chunk.
+/******/ 	// The chunk loading function for additional chunks
+/******/ 	__webpack_require__.e = function requireEnsure(chunkId, callback) {
+/******/ 		// "0" is the signal for "already loaded"
+/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 			return callback.call(null, __webpack_require__);
+
+/******/ 		// an array means "currently loading".
+/******/ 		if(installedChunks[chunkId] !== undefined) {
+/******/ 			installedChunks[chunkId].push(callback);
+/******/ 		} else {
+/******/ 			// start chunk loading
+/******/ 			installedChunks[chunkId] = [callback];
+/******/ 			var head = document.getElementsByTagName('head')[0];
+/******/ 			var script = document.createElement('script');
+/******/ 			script.type = 'text/javascript';
+/******/ 			script.charset = 'utf-8';
+/******/ 			script.async = true;
+
+/******/ 			script.src = __webpack_require__.p + "" + ({"1":"index"}[chunkId]||chunkId) + ".js";
+/******/ 			head.appendChild(script);
+/******/ 		}
+/******/ 	};
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/ })
+/************************************************************************/
+/******/ ([]);

--- a/src/__tests__/expect/build-node-builtins/index.js
+++ b/src/__tests__/expect/build-node-builtins/index.js
@@ -1,0 +1,22 @@
+webpackJsonp([1,0],[
+/* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var _fs = __webpack_require__(1);
+
+	var _fs2 = _interopRequireDefault(_fs);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	console.log(_fs2.default);
+
+/***/ },
+/* 1 */
+/***/ function(module, exports) {
+
+	
+
+/***/ }
+]);

--- a/src/__tests__/fixtures/build-node-builtins/index.html
+++ b/src/__tests__/fixtures/build-node-builtins/index.html
@@ -1,0 +1,2 @@
+<script src="dist/common.js"></script>
+<script src="dist/index.js"></script>

--- a/src/__tests__/fixtures/build-node-builtins/index.html
+++ b/src/__tests__/fixtures/build-node-builtins/index.html
@@ -1,2 +1,0 @@
-<script src="dist/common.js"></script>
-<script src="dist/index.js"></script>

--- a/src/__tests__/fixtures/build-node-builtins/index.js
+++ b/src/__tests__/fixtures/build-node-builtins/index.js
@@ -1,0 +1,2 @@
+import fs from 'fs'
+console.log(fs)

--- a/src/__tests__/fixtures/build-node-builtins/package.json
+++ b/src/__tests__/fixtures/build-node-builtins/package.json
@@ -1,0 +1,5 @@
+{
+  "entry": {
+    "index": "./index.js"
+  }
+}

--- a/src/getWebpackCommonConfig.js
+++ b/src/getWebpackCommonConfig.js
@@ -22,6 +22,18 @@ export default function getWebpackCommonConfig(args) {
     plugins: ['add-module-exports'],
   };
 
+  const emptyBuildins = ['child_process', 'cluster', 'dgram', 'dns', 'fs', 'module', 'net', 'readline', 'repl', 'tls'];
+
+  const browser = pkg.browser || {};
+
+  const node = emptyBuildins.reduce((obj, name)=>{
+    if ( !(name in browser) ) {
+      obj[name] = 'empty';
+    }
+    return obj;
+  }, {});
+
+
   return {
 
     output: {
@@ -42,6 +54,8 @@ export default function getWebpackCommonConfig(args) {
     },
 
     entry: pkg.entry,
+
+    node,
 
     module: {
       loaders: [


### PR DESCRIPTION
Some modules will support node and web:

```javascript
if (typeof require !== 'undefined' && typeof exports !== 'undefined') {
  var fs = require('fs')
  /***/
}
```

error:Module not found: Error: Cannot resolve module 'fs'