### PR TITLE
export get webpeck function, if user need to (for example, Karma test…

### DIFF
--- a/bin/atool-build
+++ b/bin/atool-build
@@ -13,5 +13,4 @@ program
   .option('--verbose', 'run with more logging messages.')
   .parse(process.argv);
 
-program.cwd = process.cwd();
 require('../lib/build')(program);

--- a/src/build.js
+++ b/src/build.js
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import mergeCustomConfig from './mergeCustomConfig';
 import getWebpackCommonConfig from './getWebpackCommonConfig';
 
-function getWebpackConfig(args) {
+export function getWebpackConfig(args) {
   let webpackConfig = getWebpackCommonConfig(args);
 
   webpackConfig.plugins = webpackConfig.plugins || [];
@@ -37,6 +37,11 @@ function getWebpackConfig(args) {
     new webpack.optimize.DedupePlugin(),
     new webpack.NoErrorsPlugin(),
   ];
+
+  // use current directory if cwd is not set
+  if (!args.cwd) {
+    args.cwd = process.cwd();
+  }
 
   // Output map.json if hash.
   if (args.hash) {


### PR DESCRIPTION
在使用atool-build的过程中，有时候需要能够获得webpack的对象，比如我们想用karma来做测试，需要和webpack集成

希望可以把获取webpack对象的方法暴露出来