### PR TITLE
bugfix: loader not found with using tnpm4 when project's pkg existing…

### DIFF
--- a/src/getWebpackCommonConfig.js
+++ b/src/getWebpackCommonConfig.js
@@ -98,7 +98,7 @@ export default function getWebpackCommonConfig(args) {
           loader: ExtractTextPlugin.extract(
             'css?sourceMap!' +
             'postcss!' +
-            `less?{"sourceMap":true,"modifyVars":${JSON.stringify(pkg.theme || {})}}`
+            `less-loader?{"sourceMap":true,"modifyVars":${JSON.stringify(pkg.theme || {})}}`
           ),
         },
         {
@@ -106,7 +106,7 @@ export default function getWebpackCommonConfig(args) {
           loader: ExtractTextPlugin.extract(
             'css?sourceMap&modules&localIdentName=[local]___[hash:base64:5]!!' +
             'postcss!' +
-            `less?{"sourceMap":true,"modifyVars":${JSON.stringify(pkg.theme || {})}}`
+            `less-loader?{"sourceMap":true,"modifyVars":${JSON.stringify(pkg.theme || {})}}`
           ),
         },
         { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: 'url?limit=10000&minetype=application/font-woff' },


### PR DESCRIPTION
bugfix: loader not found with using tnpm4 when project's pkg existing extra less.

More info about the solution: http://stackoverflow.com/questions/29883534/webpack-node-modules-css-index-js-didnt-return-a-function