### PR TITLE
fix: should check package.json before require it

### DIFF
--- a/src/getWebpackCommonConfig.js
+++ b/src/getWebpackCommonConfig.js
@@ -1,12 +1,14 @@
 import webpack from 'webpack';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import getBabelCommonConfig from './getBabelCommonConfig';
+import { existsSync } from 'fs';
 import { join } from 'path';
 import rucksack from 'rucksack-css';
 import autoprefixer from 'autoprefixer';
 
 export default function getWebpackCommonConfig(args) {
-  const pkg = require(join(args.cwd, 'package.json'));
+  const pkgPath = join(args.cwd, 'package.json');
+  const pkg = existsSync(pkgPath) ? require(pkgPath) : {};
 
   const jsFileName = args.hash ? '[name]-[chunkhash].js' : '[name].js';
   const cssFileName = args.hash ? '[name]-[chunkhash].css' : '[name].css';


### PR DESCRIPTION
既然 `package.json` 中的各字段都是可选的，那么 `package.json` 本身应该也是可选的。

不然在 `dora` 里面修改 `cwd` 后会因为 `package.json` 不存在而报错。