### PR TITLE
Adding ".json" to the extensions under resolve

### DIFF
--- a/src/getWebpackCommonConfig.js
+++ b/src/getWebpackCommonConfig.js
@@ -73,7 +73,7 @@ export default function getWebpackCommonConfig(args) {
 
     resolve: {
       modulesDirectories: ['node_modules', join(__dirname, '../node_modules')],
-      extensions: ['', '.web.tsx', '.web.ts', '.web.jsx', '.web.js', '.ts', '.tsx', '.js', '.jsx'],
+      extensions: ['', '.web.tsx', '.web.ts', '.web.jsx', '.web.js', '.ts', '.tsx', '.js', '.jsx', '.json'],
     },
 
     resolveLoader: {


### PR DESCRIPTION
cannot resolve package of babel core when build:

![image](https://cloud.githubusercontent.com/assets/2723376/16641991/bd6d7bfe-4438-11e6-8ca1-4d7619fc878b.png)

Adding ".json" to the extensions under resolve to fix this.

reference: http://stackoverflow.com/questions/37270503/webpack-cannot-resolve-package-of-babel-core