### PR TITLE
support import modules in style/*.less

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "json-loader": "~0.5.4",
     "less": "~2.6.0",
     "less-loader": "~2.2.0",
+    "less-plugin-npm-import": "^2.1.0",
     "map-json-webpack-plugin": "~1.1.0",
     "postcss": "^5.0.19",
     "postcss-loader": "~0.8.0",

--- a/src/transformLess.js
+++ b/src/transformLess.js
@@ -4,6 +4,7 @@ import path, { dirname } from 'path';
 import postcss from 'postcss';
 import rucksack from 'rucksack-css';
 import autoprefixer from 'autoprefixer';
+import NpmImportPlugin from 'less-plugin-npm-import';
 
 function transformLess(lessFile, config = {}) {
   const { cwd = process.cwd() } = config;
@@ -17,6 +18,9 @@ function transformLess(lessFile, config = {}) {
     const lessOpts = {
       paths: [dirname(resolvedLessFile)],
       filename: resolvedLessFile,
+      plugins: [
+        new NpmImportPlugin({ prefix: '~' }),
+      ],
     };
     less.render(data, lessOpts)
       .then(result => {

--- a/test/expect/transformLess/a.css
+++ b/test/expect/transformLess/a.css
@@ -1,0 +1,19 @@
+.c {
+  color: yellow;
+}
+.b {
+  color: red;
+}
+.a {
+  color: '#ccc';
+  -webkit-transform: translateX(1);
+      -ms-transform: translateX(1);
+          transform: translateX(1);
+}
+.a .foo {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}

--- a/test/fixtures/transformLess/a.less
+++ b/test/fixtures/transformLess/a.less
@@ -1,3 +1,4 @@
+@import "~external-package/c.less";
 @import "./b.less";
 
 @green: '#ccc';

--- a/test/fixtures/transformLess/node_modules/external-package/c.less
+++ b/test/fixtures/transformLess/node_modules/external-package/c.less
@@ -1,0 +1,3 @@
+.c {
+  color: yellow;
+}

--- a/test/transformLess-test.js
+++ b/test/transformLess-test.js
@@ -6,27 +6,10 @@ import transformLess from '../src/transformLess';
 const cwd = process.cwd();
 
 describe('lib/transformLess', () => {
-  const expected = `.b {
-  color: red;
-}
-.a {
-  color: '#ccc';
-  -webkit-transform: translateX(1);
-      -ms-transform: translateX(1);
-          transform: translateX(1);
-}
-.a .foo {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
-`;
-
   it('should build normally', () => {
     return transformLess('./test/fixtures/transformLess/a.less', { cwd })
       .then(result => {
+        const expected = readFileSync(join(cwd, './test/expect/transformLess/a.css'), 'utf-8')
         expect(result).toEqual(expected);
       });
   });


### PR DESCRIPTION
现在在 `style/index.less` 里写 `@import '~xxx/lib/xxx'` 这种，`transformLess` 的时候会路径报错。